### PR TITLE
Provide workaround for PHP 5.3.3 bug number 52854.

### DIFF
--- a/lib/CHH/Silex/CacheServiceProvider.php
+++ b/lib/CHH/Silex/CacheServiceProvider.php
@@ -58,7 +58,12 @@ class CacheServiceProvider implements ServiceProviderInterface
                     }
                 }
 
-                $cache = $class->newInstanceArgs($newInstanceArguments);
+                // Workaround for PHP 5.3.3 bug #52854 <https://bugs.php.net/bug.php?id=52854>
+                if (count($newInstanceArguments) > 0) {
+                    $cache = $class->newInstanceArgs($newInstanceArguments);
+                } else {
+                    $cache = $class->newInstanceArgs();
+                }
 
                 if (!$cache instanceof Cache) {
                     throw new \UnexpectedValueException(sprintf(


### PR DESCRIPTION
There is a bug in PHP 5.3.3 (number 52854) when passing an empty array to the `ReflectionClass::newInstanceArgs` method which causes a fatal error. Instead, no argument must be passed. The `composer.json` file says that PHP ">=5.3.3" is supported by this library. Either this workaround should be implemented or the minimum supported version should be bumped to PHP 5.3.4 (in which this bug is fixed).
